### PR TITLE
remove .powrc

### DIFF
--- a/.powrc
+++ b/.powrc
@@ -1,4 +1,0 @@
-if [ -f "$rvm_path/scripts/rvm" ] && [ -f ".rvmrc" ]; then
-  source "$rvm_path/scripts/rvm"
-  source ".rvmrc"
-fi


### PR DESCRIPTION
Just some cleanup.

[Pow](http://pow.cx/) is a mac osx rack server, and there's a `.powrc` pow config file in this repo. Was probably used for local development of the app, but the config file doesn't belong in the project.