### PR TITLE
fix logging in user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,17 +40,17 @@ class User < ActiveRecord::Base
     case status
     when :on
       go_on_call
-      logger.info "[User] User:#{params[:id]} on call now, #{Time.zone.now}"
+      logger.info "[User] User:#{self.id} on call now, #{Time.zone.now}"
     when :off
       go_off_call
-      logger.info "[User] User:#{params[:id]} off call now, #{Time.zone.now}"
+      logger.info "[User] User:#{self.id} off call now, #{Time.zone.now}"
     else
       if on_call
         go_off_call
-        logger.info "[User] User:#{params[:id]} off call now, #{Time.zone.now}"
+        logger.info "[User] User:#{self.id} off call now, #{Time.zone.now}"
       else
         go_on_call
-        logger.info "[User] User:#{params[:id]} on call now, #{Time.zone.now}"
+        logger.info "[User] User:#{self.id} on call now, #{Time.zone.now}"
       end
     end
   end


### PR DESCRIPTION
@sarahmaeve shared a stack trace which included:
`NameError (undefined local variable or method 'params' for #<User:0x007fb18955b8c8>`

`params` isn't accessible outside of a controller. This PR correctly references the `id` on the `user` object, instead of trying to access `params`.