### PR TITLE
Require new passwords to meet security requirements.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class UsersController < AdminController
+    include UsersHelper
+
     def show
       @user = User.find(params[:id])
     end
@@ -7,11 +9,22 @@ module Admin
     def update
       @user = User.find(params[:id])
       @user.admin_updating_user = true
-      @user.password = params[:password] if params[:password]
-      if @user.save
-        redirect_to edit_user_path(@user.id), :notice => "User has been updated"
-      else
-        redirect_to({:action => "show", :id => @user.id}, {:notice => "User could not be saved"})
+      save = true
+      if params[:password]
+        if secure_password?(params[:password])
+          @user.password = params[:password]
+        else
+          redirect_to({:action => "show", :id => @user.id}, {:notice => "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"})
+          save = false
+        end
+      end
+
+      if save
+        if @user.save
+          redirect_to edit_user_path(@user.id), :notice => "User has been updated"
+        else
+          redirect_to({:action => "show", :id => @user.id}, {:notice => "User could not be saved"})
+        end
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,34 +1,17 @@
 module Admin
   class UsersController < AdminController
-    include UsersHelper
-
     def show
       @user = User.find(params[:id])
-      if params.key?(:force_reset)
-        flash.now.alert = "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
-        render
-      end
     end
 
     def update
       @user = User.find(params[:id])
       @user.admin_updating_user = true
-      save = true
-      if params[:password]
-        if secure_password?(params[:password])
-          @user.password = params[:password]
-        else
-          redirect_to({:action => "show", :id => @user.id}, {:notice => "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"})
-          save = false
-        end
-      end
-
-      if save
-        if @user.save
-          redirect_to edit_user_path(@user.id), :notice => "User has been updated"
-        else
-          redirect_to({:action => "show", :id => @user.id}, {:notice => "User could not be saved"})
-        end
+      @user.password = params[:password] if params[:password]
+      if @user.save
+        redirect_to edit_user_path(@user.id), :notice => "User has been updated"
+      else
+        redirect_to({:action => "show", :id => @user.id}, {:notice => "User could not be saved. Did you fulfill the password requirements?"})
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,6 +4,10 @@ module Admin
 
     def show
       @user = User.find(params[:id])
+      if params.key?(:force_reset)
+        flash.now.alert = "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
+        render
+      end
     end
 
     def update

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
       if secure_password?(params[:session][:password])
         redirect_to dashboard_url, :notice => "Logged in!"
       else
-        redirect_to "/set-password/#{user.token}?force_reset"
+        redirect_to set_password_url(:token => user.token), :notice => "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
       end
     else
       flash.now.alert = "Invalid email or password"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,7 @@ class SessionsController < ApplicationController
       if secure_password?(params[:session][:password])
         redirect_to dashboard_url, :notice => "Logged in!"
       else
-        redirect_to "/admin/users/#{user.id}?force_reset"
+        redirect_to "/set-password/#{user.token}?force_reset"
       end
     else
       flash.now.alert = "Invalid email or password"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  include UsersHelper
+
   def new
     logout
   end
@@ -23,7 +25,12 @@ class SessionsController < ApplicationController
       url = session[:return_to] ? session[:return_to] : root_url
       url = root_url if url.include?('/login')
       session[:return_to] = nil
-      redirect_to dashboard_url, :notice => "Logged in!"
+
+      if secure_password?(params[:session][:password])
+        redirect_to dashboard_url, :notice => "Logged in!"
+      else
+        redirect_to "/admin/users/#{user.id}?force_reset"
+      end
     else
       flash.now.alert = "Invalid email or password"
       # log failures so we can set up alerting on account hack attempts

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,13 +38,17 @@ class UsersController < ApplicationController
   end
 
   def save_password
-    @user = User.find_by_token(params[:token])
-    if @user && @user.update_attributes(params[:user].slice(:password, :password_confirmation, :phone))
-      @user.reload
-      login(@user)
-      redirect_to dashboard_url
+    if not UsersHelper.secure_password?(params[:user].slice(:password))
+      redirect_to set_password_url(:token => params[:token]), :notice => "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
     else
-      redirect_to set_password_url(:token => params[:token]), :notice => "Something went wrong, try again."
+      @user = User.find_by_token(params[:token])
+      if @user && @user.update_attributes(params[:user].slice(:password, :password_confirmation, :phone))
+        @user.reload
+        login(@user)
+        redirect_to dashboard_url
+      else
+        redirect_to set_password_url(:token => params[:token]), :notice => "Something went wrong, try again."
+      end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,11 +37,6 @@ class UsersController < ApplicationController
       flash.now.alert = "Invalid link"
       redirect_to root_url
     end
-
-    if params.key?(:force_reset)
-      flash.now.alert = "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
-      render
-    end
   end
 
   def save_password

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  include UsersHelper
+
   before_filter :require_login, :except => [:set_password, :save_password, :apply, :apply_thanks, :create, :unsubscribe]
   before_filter :require_admin, :only => [:index, :new, :destroy, :show, :approve]
 
@@ -35,20 +37,26 @@ class UsersController < ApplicationController
       flash.now.alert = "Invalid link"
       redirect_to root_url
     end
+
+    if params.key?(:force_reset)
+      flash.now.alert = "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
+      render
+    end
   end
 
   def save_password
-    if not UsersHelper.secure_password?(params[:user].slice(:password))
+    if not secure_password?(params[:user].slice(:password)["password"])
       redirect_to set_password_url(:token => params[:token]), :notice => "Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*). Help keep Trans Lifeline safe!"
+      return
+    end
+
+    @user = User.find_by_token(params[:token])
+    if @user && @user.update_attributes(params[:user].slice(:password, :password_confirmation, :phone))
+      @user.reload
+      login(@user)
+      redirect_to dashboard_url
     else
-      @user = User.find_by_token(params[:token])
-      if @user && @user.update_attributes(params[:user].slice(:password, :password_confirmation, :phone))
-        @user.reload
-        login(@user)
-        redirect_to dashboard_url
-      else
-        redirect_to set_password_url(:token => params[:token]), :notice => "Something went wrong, try again."
-      end
+      redirect_to set_password_url(:token => params[:token]), :notice => "Something went wrong, try again."
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -11,14 +11,23 @@ module UsersHelper
 			total_hours = (total_minutes / 60).to_s
 			left_over_minutes = (total_minutes % 60).to_s
 			if left_over_minutes.length == 1
-				left_over_minutes = "0" + left_over_minutes[0] 
+				left_over_minutes = "0" + left_over_minutes[0]
 			end
-			formated_time = total_hours + ":" + left_over_minutes 
+			formated_time = total_hours + ":" + left_over_minutes
 			return formated_time
 		else
 			return 0
 		end
 	end
 
-end
+	def secure_password?(password)
+		special_characters = "@%!*\$\^"
+		password_length = 8
 
+		valid_length = password.length >= password_length
+		has_special_character = (/[#{special_characters}]+/ =~ password) != nil
+		has_number = (/[0-9]+/ =~ password) != nil
+
+		valid_length and has_special_character and has_number
+	end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ActiveRecord::Base
 
   validates_confirmation_of :password, :unless => :no_password_required
   validates_presence_of :password, :unless => :no_password_required
+  validates :password, :secure_password => true
   validates_presence_of :name
   validates_uniqueness_of :email, :scope => :deleted_at
   validates_uniqueness_of :phone, :scope => :deleted_at, :unless => Proc.new {|u| u.phone.blank? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ActiveRecord::Base
 
   validates_confirmation_of :password, :unless => :no_password_required
   validates_presence_of :password, :unless => :no_password_required
-  validates :password, :secure_password => true
+  validates :password, :secure_password => true, :unless => :no_password_required
   validates_presence_of :name
   validates_uniqueness_of :email, :scope => :deleted_at
   validates_uniqueness_of :phone, :scope => :deleted_at, :unless => Proc.new {|u| u.phone.blank? }

--- a/lib/secure_password_validator.rb
+++ b/lib/secure_password_validator.rb
@@ -1,0 +1,9 @@
+class SecurePasswordValidator < ActiveModel::EachValidator
+  include UsersHelper
+
+  def validate_each(record, attribute, value)
+    if not secure_password?(value)
+      record.errors[attribute] << ("Password does not meet our security requirements. Please use a password at least 8 characters long, including a number and a special character ($@%^!*).")
+    end
+  end
+end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe UsersHelper, :type => :helper do
+  describe "secure_password?" do
+    it "should be true for secure passwords" do
+      expect(helper.secure_password?("password1!")).to eq(true)
+    end
+
+    it "should be false for insecure passwords" do
+      # Too short
+      expect(helper::secure_password?("pass1!")).to eq(false)
+
+      # Missing special character
+      expect(helper::secure_password?("password1")).to eq(false)
+
+      # Missing number
+      expect(helper::secure_password?("password!")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
New passwords must now be at least 8 characters long, and contain a number and a special character ($@%^!*).

This diff validates passwords both on the client side and when storing them to the DB. In addition to unit tests, I manually verified that changing a user's password in the "My Info" > "Administration" enforces the security requirements. I was not able to simulate setting the password on account creation locally, so the code to enforce it is there but has not been tested.